### PR TITLE
fix prop type error

### DIFF
--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -73,7 +73,7 @@ Button.propTypes = {
 		"black",
 		"white",
 	]),
-	children: PropTypes.elementType,
+	children: PropTypes.node,
 	disabled: PropTypes.bool,
 	block: PropTypes.bool,
 };

--- a/src/components/NavRoute/index.jsx
+++ b/src/components/NavRoute/index.jsx
@@ -15,7 +15,7 @@ function NavRoute({ component: Component, ...rest }) {
 }
 
 NavRoute.propTypes = {
-	component: PropTypes.element,
+	component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
 export default NavRoute;


### PR DESCRIPTION
- NavRoute's component prop changed to oneOfType([ string, func ])
- Button's children prop changed to PropType.node